### PR TITLE
bnc#873641 remove redundant secondary icon of search entry

### DIFF
--- a/src/shell.ui
+++ b/src/shell.ui
@@ -78,9 +78,6 @@
                                     <property name="visible">True</property>
                                     <property name="can_focus">True</property>
                                     <property name="invisible_char">&#x25CF;</property>
-                                    <property name="secondary-icon-name">edit-find-symbolic</property>
-                                    <property name="secondary-icon-activatable">False</property>
-                                    <property name="secondary-icon-sensitive">False</property>
                                   </object>
                                 </child>
                                 <child>


### PR DESCRIPTION
Original summary of bnc#873641:
"Two Magnifier symbols in search bar of Yast Administrator Settings window"
"The Gtk+ version of the Yast Administrator Settings window in OpenSUSE 13.1,
SLED 12 beta 4, and SLES 12 beta 4 has a bug where it shows a Magnifier icon on
both sides of the search bar initially.
The icon on the right of the bar hides after some using the bar."

It seems the definition of secondary icon in src/shell.ui caused this.
